### PR TITLE
Retrieve all houses on request

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -154,10 +154,22 @@ export default new Vuex.Store({
     },
     async getHouseData({ commit }) {
       try {
-        let response = await axios.get("/api/v1/houses");
-        if (response.status === 200) {
-          commit("updateHouses", response.data);
-        }
+        // TODO: Paginate the houses, instead of retrieving all of them.
+        let page = 1;
+        let houses = {};
+        let results = [];
+        let next = "first";
+        do {
+          let response = await axios.get(`/api/v1/houses?page=${page}`);
+          if (response.status === 200) {
+            results = results.concat(response.data.results);
+          }
+          next = response.data.next;
+          page++;
+        } while (next);
+        houses.count = Object.keys(results).length;
+        houses.results = results.reverse();
+        commit("updateHouses", houses);
       } catch (error) {
         commit("displayToast", {
           display: true,


### PR DESCRIPTION
Since the API does not retrieve all of the results, we must iterate through the pagination to get all of the data.